### PR TITLE
WIP: On exit before restart

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ impl ProcessManager {
 		}
 		let mut inner = self.inner.write().await;
 		debug!(
-			"starting process '{}{}{}'",
+			"starting process '{} {} {}'",
 			process.env_text(),
 			process.exe_text(),
 			process.args_text()
@@ -166,7 +166,7 @@ impl ProcessManager {
 			.map_err(Error::Process)?;
 		process_data.restarts += 1;
 		debug!(
-			"restarted process '{}{}{}', now at {} restarts",
+			"restarted process '{} {} {}', now at {} restarts",
 			process_data.process.env_text(),
 			process_data.process.exe_text(),
 			process_data.process.args_text(),
@@ -261,7 +261,7 @@ impl ProcessManager {
             .into_iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-            pdata.process.env.retain(|(k, _)| !new_env.iter().any(|(k_new, _)| k != k_new));
+            pdata.process.env.retain(|(k, _)| !new_env.iter().any(|(k_new, _)| k == k_new));
             pdata.process.env.append(&mut new_env);
                 Ok(())
         } else {
@@ -269,7 +269,7 @@ impl ProcessManager {
         }
     }
 
-    pub async fn clear_process_env(&mut self, key: &ProcessKey, env: impl IntoIterator<Item = (impl ToString, impl ToString)>,) -> Result<()> {
+    pub async fn clear_process_env(&mut self, key: &ProcessKey) -> Result<()> {
         let mut r = self.inner.write().await;
         if let Some(pdata) = r.processes.get_mut(*key) {
             pdata.process.env.clear();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,8 @@ impl ProcessManager {
 						!ret.success() && (inner.max_restarts > process.restarts)
 					};
 					if let Some(on_exit) = &callbacks.on_exit {
-						let _ = callback_tx.send(on_exit(self.clone(), key, ret.code(), is_restarting));
+                        // wait for this to complete before potentially restarting
+						on_exit(self.clone(), key, ret.code(), is_restarting).await;
 					}
 					if is_restarting {
 						match self.restart_process(key).await {
@@ -251,6 +252,32 @@ impl ProcessManager {
 			}
 		}
 	}
+
+    /// update the env of an existing process
+    pub async fn update_process_env(&mut self, key: &ProcessKey, env: impl IntoIterator<Item = (impl ToString, impl ToString)>) -> Result<()> {
+        let mut r = self.inner.write().await;
+        if let Some(pdata) = r.processes.get_mut(*key) {
+            let mut new_env: Vec<(_,_)> = env
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+            pdata.process.env.retain(|(k, _)| !new_env.iter().any(|(k_new, _)| k != k_new));
+            pdata.process.env.append(&mut new_env);
+                Ok(())
+        } else {
+            Err(Error::NonExistantProcess)
+        }
+    }
+
+    pub async fn clear_process_env(&mut self, key: &ProcessKey, env: impl IntoIterator<Item = (impl ToString, impl ToString)>,) -> Result<()> {
+        let mut r = self.inner.write().await;
+        if let Some(pdata) = r.processes.get_mut(*key) {
+            pdata.process.env.clear();
+            Ok(())
+        } else {
+            Err(Error::NonExistantProcess)
+        }
+    }
 }
 
 struct ProcessData {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,11 @@ use self::{
 	process::{Process, ProcessCallbacks, ReturnFuture},
 };
 use slotmap::{new_key_type, SlotMap};
-use std::{collections::VecDeque, process::Stdio, sync::Arc};
+use std::{process::Stdio, sync::Arc};
 use tokio::{
 	io::{AsyncBufReadExt, BufReader},
 	process::{Child, Command},
-	sync::{mpsc, oneshot, Mutex, RwLock},
+	sync::{mpsc, oneshot, RwLock},
 };
 use tokio_util::sync::CancellationToken;
 
@@ -130,37 +130,21 @@ impl ProcessManager {
 		// to both ensure execution of callbacks is in the same order the events are
 		// received, and to avoid blocking the reception of events if a callback is slow
 		// to return.
-		let queue = Arc::new(Mutex::new(VecDeque::<ReturnFuture>::new()));
-		let queue_clone = queue.clone();
-		let queue_token = cancel_token.child_token();
-		// tokio::spawn(async move {
-		// 	loop {
-        //         println!("busy looping");
-		// 		let call_next = async {
-		// 			let queued_callback = { queue_clone.lock().await.pop_front() };
-		// 			if let Some(future) = queued_callback {
-		// 				future.await;
-		// 			};
-		// 			tokio::task::yield_now().await
-		// 		};
-		// 		tokio::select! {
-		// 			_ = call_next => continue,
-		// 			_ = queue_token.cancelled() => break,
-		// 		}
-		// 	}
-		// });
+		let (callback_tx, mut callback_rx) = mpsc::unbounded_channel();
+		tokio::spawn(async move {
+			while let Some(f) = callback_rx.recv().await {
+                f.await
+            } 
+		});
 		if let Some(on_start) = &callbacks.on_start {
-			queue
-				.lock()
-				.await
-				.push_back(on_start(self.clone(), key, false));
+			let _ = callback_tx.send(on_start(self.clone(), key, false));
 		}
 		tokio::spawn(self.clone().process_loop(
 			key,
 			cancel_token.child_token(),
 			command,
 			callbacks,
-			queue,
+			callback_tx,
 		));
 		Ok(key)
 	}
@@ -197,7 +181,7 @@ impl ProcessManager {
 		cancel_token: CancellationToken,
 		mut command: Child,
 		callbacks: ProcessCallbacks,
-		queue: Arc<Mutex<VecDeque<ReturnFuture>>>,
+		callback_tx: mpsc::UnboundedSender<ReturnFuture>,
 	) {
 		let (mut stdout, mut stderr) = match (command.stdout.take(), command.stderr.take()) {
 			(Some(stdout), Some(stderr)) => (
@@ -219,12 +203,12 @@ impl ProcessManager {
 				},
 				Ok(Some(stdout_line)) = stdout.next_line() => {
 					if let Some(on_stdout) = &callbacks.on_stdout {
-						tokio::spawn(on_stdout(self.clone(), key, stdout_line));
+						let _ = callback_tx.send(on_stdout(self.clone(), key, stdout_line));
 					}
 				}
 				Ok(Some(stderr_line)) = stderr.next_line() => {
 					if let Some(on_stderr) = &callbacks.on_stderr {
-						tokio::spawn(on_stderr(self.clone(), key, stderr_line));
+						let _ = callback_tx.send(on_stderr(self.clone(), key, stderr_line));
 					}
 				}
 				ret = command.wait() => {
@@ -235,7 +219,7 @@ impl ProcessManager {
 						!ret.success() && (inner.max_restarts > process.restarts)
 					};
 					if let Some(on_exit) = &callbacks.on_exit {
-						tokio::spawn(on_exit(self.clone(), key, ret.code(), is_restarting));
+						let _ = callback_tx.send(on_exit(self.clone(), key, ret.code(), is_restarting));
 					}
 					if is_restarting {
 						match self.restart_process(key).await {
@@ -253,7 +237,7 @@ impl ProcessManager {
 									}
 								};
 								if let Some(on_start) = &callbacks.on_start {
-									tokio::spawn(on_start(self.clone(), key, true));
+									let _ = callback_tx.send(on_start(self.clone(), key, true));
 								}
 								continue;
 							}


### PR DESCRIPTION
This is a WIP. The goal is to allow the cosmic-panel to update the env-vars, of the Process in the on_quit callback, and ensure that the change is applied before the process restarts. The same kind of methods could be added for other process variables though.