### PR TITLE
added function for pid

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -10,6 +10,9 @@ pub type StringCallback =
 	Box<dyn Fn(ProcessManager, ProcessKey, String) -> ReturnFuture + Send + Sync + 'static>;
 pub type StartedCallback =
 	Box<dyn Fn(ProcessManager, ProcessKey, bool) -> ReturnFuture + Send + Sync + 'static>;
+/// Type for the callback that is called when a process exits. Arguments are the
+/// process manager, the process key, the error code to return, and a
+/// bool indicating if the process is going to be restarted.
 pub type ExitedCallback = Box<
 	dyn Fn(ProcessManager, ProcessKey, Option<i32>, bool) -> ReturnFuture + Send + Sync + 'static,
 >;


### PR DESCRIPTION
Added a field to `ProcessData` for storing the pid, and a public function to ProcessManager for accessing it. 

A couple of questions. 
1. is there a reason [`ProcessData` is added to the manager prior to launching the command](https://github.com/pop-os/launch-pad/blob/699fd1801260cd4425dfd472d0e36fdf17bb7f36/src/lib.rs#L151)? I'm mainly wondering because I can avoid the mutable reference and making pid optional if I reorder these.
2. Where should test (for the `processManager` public function) be defined? 