### PR TITLE
fix: Don't panic if kill signal fails.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,7 +396,9 @@ impl ProcessManager {
 					}
 
 					if exit_code.is_none() {
-						command.kill().await.expect("failed to kill program");
+						if let Err(err) = command.kill().await {
+							log::error!("Failed to kill program. {err:?}");
+						};
 						exit_code = Some(137);
 					}
 


### PR DESCRIPTION
I've noticed in the logs that launch pad will panic if i send a kill signal to an app running under cosmic session and then it is cancelled. I think it might be best to just log an error or warning instead.